### PR TITLE
Ensure interactive display driver finalizes when render is terminated

### DIFF
--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -481,6 +481,21 @@ class RenderCallback : public IECore::RefCounted
 			: m_session( nullptr ), m_interactive( interactive ), m_displayDriver( nullptr )
 		{
 		}
+		
+		~RenderCallback()
+		{
+			if( m_displayDriver )
+			{
+				try
+				{
+					m_displayDriver->imageClose();
+				}
+				catch( const std::exception &e )
+				{
+					IECore::msg( IECore::Msg::Error, "DisplayDriver::imageClose", e.what() );
+				}
+			}
+		}
 
 		void updateSession( ccl::Session *session )
 		{


### PR DESCRIPTION
Interactive renders aren't being saved to disk, adding this to the RenderCallback destructor seems to do the trick.