### PR TITLE
Shader Ball

### DIFF
--- a/python/GafferCycles/CyclesShaderBall.py
+++ b/python/GafferCycles/CyclesShaderBall.py
@@ -1,0 +1,97 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Murray Stevenson. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferCycles
+
+class CyclesShaderBall( GafferScene.ShaderBall ) :
+
+	def __init__( self, name = "CyclesShaderBall" ) :
+
+		GafferScene.ShaderBall.__init__( self, name )
+
+		self["environment"] = Gaffer.StringPlug( defaultValue = "${GAFFER_ROOT}/resources/hdri/studio.exr" )
+
+		# Cycles doesn't support primitives spheres
+		self["__sphere"]["type"].setValue( self["__sphere"].Type.Mesh )
+		self["__sphere"]["divisions"].setValue( imath.V2i( 60, 120 ) )
+
+		self["__environment_texture"] = GafferCycles.CyclesShader()
+		self["__environment_texture"].loadShader( "environment_texture" )
+		self["__environment_texture"]["parameters"]["filename"].setInput( self["environment"] )
+		self["__environment_texture"]["parameters"]["tex_mapping__scale"].setValue( imath.V3f( -1, 1, 1 ) )
+		self["__environment_texture"]["parameters"]["tex_mapping__y_mapping"].setValue( 3 )
+		self["__environment_texture"]["parameters"]["tex_mapping__z_mapping"].setValue( 2 )
+		self["__environment_texture"]['parameters']['tex_mapping__rotation']['z'].setValue( -1.5708 )
+
+		self["__background_shader"] = GafferCycles.CyclesShader()
+		self["__background_shader"].loadShader( "background_shader" )
+		self["__background_shader"]["parameters"]["color"].setInput( self["__environment_texture"]["out"]["color"] )
+
+		self["__background"] = GafferCycles.CyclesBackground()
+		self["__background"]["shader"].setInput( self["__background_shader"]["out"]["background"] )
+		self["__background"]["in"].setInput( self._outPlug().getInput() )
+
+		self["__background_light"] = GafferCycles.CyclesLight()
+		self["__background_light"].loadShader( "background_light" )
+
+		self["__parentLights"] = GafferScene.Parent()
+		self["__parentLights"]["in"].setInput( self["__background"]["out"] )
+		self["__parentLights"]["children"][0].setInput( self["__background_light"]["out"] )
+		self["__parentLights"]["parent"].setValue( "/" )
+
+		self["__cyclesOptions"] = GafferCycles.CyclesOptions()
+		self["__cyclesOptions"]["in"].setInput( self["__parentLights"]["out"] )
+
+		self.addChild(
+			self["__cyclesOptions"]["options"]["device"].createCounterpart( "device", Gaffer.Plug.Direction.In )
+		)
+		Gaffer.MetadataAlgo.copy( self["__cyclesOptions"]["options"]["device"], self["device"], exclude="layout:*" )
+		self["__cyclesOptions"]["options"]["device"].setInput( self["device"] )
+
+		self.addChild(
+			self["__cyclesOptions"]["options"]["numThreads"].createCounterpart( "threads", Gaffer.Plug.Direction.In )
+		)
+		self["__cyclesOptions"]["options"]["numThreads"].setInput( self["threads"] )
+
+		self._outPlug().setInput( self["__cyclesOptions"]["out"] )
+
+IECore.registerRunTimeTyped( CyclesShaderBall, typeName = "GafferCycles::CyclesShaderBall" )

--- a/python/GafferCyclesUI/CyclesShaderBallUI.py
+++ b/python/GafferCyclesUI/CyclesShaderBallUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2018, Alex Fuller. All rights reserved.
+#  Copyright (c) 2019, Murray Stevenson. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,9 +34,60 @@
 #
 ##########################################################################
 
-__import__( "GafferScene" )
+import Gaffer
+import GafferCycles
 
-from _GafferCycles import *
-from CyclesShaderBall import CyclesShaderBall
+Gaffer.Metadata.registerNode(
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferCycles" )
+	GafferCycles.CyclesShaderBall,
+
+	"description",
+	"""
+	Generates scenes suitable for rendering shader balls with Cycles.
+	""",
+
+	"layout:activator:deviceIsCpuOrMulti", lambda node : node["device"]["value"].getValue() in ["CPU", "MULTI"],
+
+	plugs = {
+
+		"environment" : [
+
+			"description",
+			"""
+			An environment map used for lighting. Should be in latlong
+			format.
+			""",
+
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"path:leaf", True,
+			"path:valid", True,
+			"path:bookmarks", "texture",
+
+		],
+
+		"device" : [
+
+			"description",
+			"""
+			The device to render the shader ball on.
+			""",
+
+		],
+
+		"threads" : [
+
+			"description",
+			"""
+			The number of threads used by Cycles to render the
+			shader ball. A value of 0 uses all cores, and negative
+			values reserve cores for other uses - to be used by
+			the rest of the UI for instance.
+			""",
+
+			"layout:visibilityActivator", "deviceIsCpuOrMulti",
+
+		],
+
+	}
+
+)

--- a/python/GafferCyclesUI/__init__.py
+++ b/python/GafferCyclesUI/__init__.py
@@ -41,6 +41,7 @@ import CyclesLightUI
 import CyclesMeshLightUI
 import CyclesOptionsUI
 import CyclesRenderUI
+import CyclesShaderBallUI
 import CyclesShaderUI
 import InteractiveCyclesRenderUI
 import ShaderMenu

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -425,6 +425,11 @@ class CyclesOutput : public IECore::RefCounted
 
 		void writeImage()
 		{
+			if( m_interactive )
+			{
+				IECore::msg( IECore::Msg::Debug, "CyclesRenderer::CyclesOutput", boost::format( "Skipping interactive output: \"%s\"." ) % m_name );
+				return;
+			}
 			if( !m_image )
 			{
 				IECore::msg( IECore::Msg::Warning, "CyclesRenderer::CyclesOutput", boost::format( "Cannot write output: \"%s\"." ) % m_name );
@@ -570,18 +575,21 @@ class RenderCallback : public IECore::RefCounted
 
 			if( m_interactive )
 			{
-				const auto bIt = m_outputs.find( "Interactive/Beauty" );
-				if( bIt != m_outputs.end() )
+				for( auto &output : m_outputs )
 				{
-					const auto parameters = bIt->second->m_parameters;
-					const StringData *driverType = parameters->member<StringData>( "driverType", true );
-					m_displayDriver = DisplayDriver::create(
-						driverType->readable(),
-						displayWindow, 
-						dataWindow, 
-						channelNames,
-						parameters
-						);
+					if( output.second->m_type == "ieDisplay" && output.second->m_data == "rgba")
+					{
+						const auto parameters = output.second->m_parameters;
+						const StringData *driverType = parameters->member<StringData>( "driverType", true );
+						m_displayDriver = DisplayDriver::create(
+							driverType->readable(),
+							displayWindow,
+							dataWindow,
+							channelNames,
+							parameters
+							);
+						break;
+					}
 				}
 			}
 		}

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2535,6 +2535,22 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				m_deviceDirty = true;
 				return;
 			}
+			else if( name == g_threadsOptionName )
+			{
+				if( value == nullptr )
+				{
+					m_sessionParams.threads = 0;
+				}
+				else if ( const IntData *data = reportedCast<const IntData>( value, "option", name ) )
+				{
+					auto threads = data->readable();
+					if( threads < 0 )
+						threads = max( ccl::system_cpu_thread_count() + threads, 1);
+					
+					m_sessionParams.threads = threads;
+				}
+				return;
+			}
 			else if( name == g_shadingsystemOptionName )
 			{
 				if( value == nullptr )
@@ -2614,7 +2630,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				OPTION_INT_C(m_sessionParams, g_tileOrderOptionName,                tile_order, ccl::TileOrder);
 				OPTION_INT  (m_sessionParams, g_startResolutionOptionName,          start_resolution);
 				OPTION_INT  (m_sessionParams, g_pixelSizeOptionName,                pixel_size);
-				OPTION_INT  (m_sessionParams, g_threadsOptionName,                  threads);
 				OPTION_BOOL (m_sessionParams, g_displayBufferLinearOptionName,      display_buffer_linear);
 				OPTION_BOOL (m_sessionParams, g_runDenoisingOptionName,             run_denoising);
 				OPTION_BOOL (m_sessionParams, g_writeDenoisingPassesOptionName,     write_denoising_passes);

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -71,7 +71,7 @@ if moduleSearchPath.find( "GafferCycles" ) :
 			searchText = "CyclesRender"
 		)
 		nodeMenu.append( "/Cycles/Interactive Render", GafferCycles.InteractiveCyclesRender, searchText = "InteractiveCyclesRender" )
-		#nodeMenu.append( "/Cycles/Shader Ball", GafferCycles.CyclesShaderBall, searchText = "CyclesShaderBall" )
+		nodeMenu.append( "/Cycles/Shader Ball", GafferCycles.CyclesShaderBall, searchText = "CyclesShaderBall" )
 
 	except Exception, m :
 

--- a/startup/gui/shaderView.py
+++ b/startup/gui/shaderView.py
@@ -47,8 +47,9 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 		result = GafferCycles.CyclesShaderBall()
 
+		# Reserve some cores for the rest of the UI
 		result["threads"]["enabled"].setValue( True )
-		result["threads"]["value"].setValue( 0 )
+		result["threads"]["value"].setValue( -3 )
 
 		return result
 

--- a/startup/gui/shaderView.py
+++ b/startup/gui/shaderView.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2018, Alex Fuller. All rights reserved.
+#  Copyright (c) 2019, Murray Stevenson. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,9 +34,22 @@
 #
 ##########################################################################
 
-__import__( "GafferScene" )
+import IECore
 
-from _GafferCycles import *
-from CyclesShaderBall import CyclesShaderBall
+import GafferSceneUI
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferCycles" )
+with IECore.IgnoredExceptions( ImportError ) :
+
+	import GafferCycles
+	GafferSceneUI.ShaderView.registerRenderer( "ccl", GafferCycles.InteractiveCyclesRender )
+
+	def __cyclesShaderBall() :
+
+		result = GafferCycles.CyclesShaderBall()
+
+		result["threads"]["enabled"].setValue( True )
+		result["threads"]["value"].setValue( 0 )
+
+		return result
+
+	GafferSceneUI.ShaderView.registerScene( "ccl", "Default", __cyclesShaderBall )


### PR DESCRIPTION
Here's a stab at getting the shader ball working. It'll only be really useful once #24 is solved, as it runs into the same issue of not finding the BSDF socket output on shaders - though previewing shaders via a cclOutput node works as expected.

As part of this I've changed the display driver creation so it no longer expects an explicit "Interactive/Beauty" output name (as the ShaderView creates an output called "Beauty"). That commit also contains a fix for interactive outputs attempting to be written to images in batch renders.

Cycles doesn't seem to support using negative thread counts to render with all but those threads, so I've added support for that when we handle the ccl:session:threads option. It's in a separate commit, feel free to include it if you think it's useful.