### PR TITLE
ccl:film:exposure now affects outputs

### DIFF
--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -176,7 +176,7 @@ CyclesOptions::CyclesOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "ccl:background:visibility:scatter", new IECore::BoolData( true ), false, "bgScatterVisibility" ) );
 
 	// Film
-	options->addChild( new Gaffer::NameValuePlug( "ccl:film:exposure", new IECore::FloatData( 0.5f ), false, "exposure" ) );
+	options->addChild( new Gaffer::NameValuePlug( "ccl:film:exposure", new IECore::FloatData( 0.8f ), false, "exposure" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ccl:film:pass_alpha_threshold", new IECore::FloatData( 0.5f ), false, "passAlphaThreshold" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ccl:film:filter_type", new IECore::IntData( 0 ), false, "filterType" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ccl:film:filter_width", new IECore::FloatData( 1.0f ), false, "filterWidth" ) );

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -647,7 +647,7 @@ class RenderCallback : public IECore::RefCounted
 			if(!buffers->copy_from_device())
 				return;
 
-			//float exposure = m_session->scene->film->exposure;
+			const float exposure = m_session->scene->film->exposure;
 
 			const int numOutputChannels = m_interactive ? m_displayDriver->channelNames().size() : 1;
 
@@ -677,13 +677,13 @@ class RenderCallback : public IECore::RefCounted
 				int numChannels = output.second->m_components;
 				if( output.second->m_passType != ccl::PASS_NONE )
 				{
-					read = buffers->get_pass_rect( output.second->m_passType, 0.5f, sample, numChannels, &tileData[0], output.second->m_data.c_str() );
+					read = buffers->get_pass_rect( output.second->m_passType, exposure, sample, numChannels, &tileData[0], output.second->m_data.c_str() );
 				}
 				else
 				{
 					if( output.second->m_denoisingPassOffsets >= 0 )
 					{
-						read = buffers->get_denoising_pass_rect( output.second->m_denoisingPassOffsets, 0.5f, sample, numChannels, &tileData[0] );
+						read = buffers->get_denoising_pass_rect( output.second->m_denoisingPassOffsets, exposure, sample, numChannels, &tileData[0] );
 					}
 				}
 
@@ -815,7 +815,7 @@ class ShaderCache : public IECore::RefCounted
 					ccl::GeometryNode *geo = new ccl::GeometryNode();
 					ccl::MathNode *math = new ccl::MathNode();
 					math->type = ccl::NODE_MATH_MULTIPLY;
-					math->value2 = 2.0f;
+					math->value2 = 1.0f;
 					ccl::ShaderNode *vecMathNode = cshader->graph->add( (ccl::ShaderNode*)vecMath );
 					ccl::ShaderNode *geoNode = cshader->graph->add( (ccl::ShaderNode*)geo );
 					ccl::ShaderNode *mathNode = cshader->graph->add( (ccl::ShaderNode*)math );


### PR DESCRIPTION
While testing the shader ball I noticed that the ccl:film:exposure option didn't do anything. Looking at the history it seems it did at one point, but then was changed to a fixed exposure of 0.5. Not sure if that was intentional or not, so here's a quick PR to fix it.

I've changed the plug default to 0.8 to match Cycles' default, though it feels to me that a default of 1.0 would be more appropriate? That's what the Blender UI provides as a default even though Cycles' internal default is 0.8.

https://github.com/boberfly/cycles/blob/89cb9a6f74b28e6f797e38304ffafdbb9b395030/src/blender/addon/properties.py#L424-L429

The default facing ratio shader is also adjusted to match Arnold at an exposure of 1.0, though we could go further and remove the multiply node from the shader if that's to become the new default.
