### PR TITLE
aperturesize, resolution, viewplane, shuttertime fixes

### DIFF
--- a/src/GafferCycles/IECoreCyclesPreview/CameraAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CameraAlgo.cpp
@@ -36,6 +36,8 @@
 #include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
 #include "GafferCycles/IECoreCyclesPreview/SocketAlgo.h"
 
+#include "Gaffer/Context.h"
+
 #include "IECoreScene/Camera.h"
 
 #include "IECore/SimpleTypedData.h"
@@ -66,7 +68,7 @@ ccl::Camera *convertCommon( const IECoreScene::Camera *camera, const std::string
 		ccam->fov = M_PI_2;
 		if( camera->getFStop() > 0.0f )
 		{
-			ccam->aperturesize = camera->getFocalLength() * camera->getFocalLengthWorldScale() / camera->getFStop();
+			ccam->aperturesize = 0.5f * camera->getFocalLength() * camera->getFocalLengthWorldScale() / camera->getFStop();
 			ccam->focaldistance = camera->getFocusDistance();
 		}
 	}
@@ -87,7 +89,7 @@ ccl::Camera *convertCommon( const IECoreScene::Camera *camera, const std::string
 
 	// Screen window/resolution TODO: full_ might be something to do with cropping?
 	const Imath::Box2f &frustum = camera->frustum();
-	const Imath::V2i &resolution = camera->getResolution();
+	const Imath::V2i &resolution = camera->renderResolution();
 	const float pixelAspectRatio = camera->getPixelAspectRatio();
 	ccam->width = resolution[0];
 	ccam->height = resolution[1];
@@ -104,6 +106,11 @@ ccl::Camera *convertCommon( const IECoreScene::Camera *camera, const std::string
 	ccam->nearclip = clippingPlanes.x;
 	ccam->farclip = clippingPlanes.y;
 	
+	// Invert the viewplane in Y so Gaffer's aperture offsets and overscan are applied in the correct direction
+	swap( ccam->viewplane.bottom, ccam->viewplane.top );
+	ccam->viewplane.bottom *= -1.0f;
+	ccam->viewplane.top *= -1.0f;
+	
 	// Crop window
 	if ( camera->hasCropWindow() )
 	{
@@ -115,27 +122,22 @@ ccl::Camera *convertCommon( const IECoreScene::Camera *camera, const std::string
 		ccam->border.clamp();
 	}
 	
-	// Shutter TODO: Need to see if this is correct or not, cycles also has a shutter curve...
+	// Shutter TODO: Cycles also has a shutter curve...
 	const Imath::V2f &shutter = camera->getShutter();
-	if ((shutter.x > 0.0) && (shutter.y > 0.0))
+	ccam->shuttertime = shutter.y - shutter.x;
+	
+	const Imath::V2f relativeShutter = shutter - Imath::V2f( Gaffer::Context::current()->getFrame() );
+	if ((relativeShutter.x >= 0.0) && (relativeShutter.y > 0.0))
 	{
 		ccam->motion_position = ccl::Camera::MOTION_POSITION_START;
-		ccam->shuttertime = shutter.x + shutter.y;
 	}
-	else if ((shutter.x < 0.0) && (shutter.y > 0.0))
-	{
-		ccam->motion_position = ccl::Camera::MOTION_POSITION_CENTER;
-		ccam->shuttertime = abs(shutter.x) + shutter.y;
-	}
-	else if ((shutter.x < 0.0) && (shutter.y <= 0.0))
+	else if ((relativeShutter.x < 0.0) && (relativeShutter.y <= 0.0))
 	{
 		ccam->motion_position = ccl::Camera::MOTION_POSITION_END;
-		ccam->shuttertime = abs(shutter.x) + abs(shutter.y);
 	}
 	else
 	{
 		ccam->motion_position = ccl::Camera::MOTION_POSITION_CENTER;
-		ccam->shuttertime = 1.0;
 	}
 
 	return ccam;


### PR DESCRIPTION
Hey Alex,

I took a closer look at the CameraAlgo behaviour and have come up with the following changes:

- ccam->aperturesize changed to radius rather than width. This matches the Blender camera conversion logic and visually matches GafferArnold.
- ccam->resolution changed to use camera->renderResolution() as this returns the resolution as modified by Gaffer's resolutionMultiplier plug.
- ccam->viewplane.top and .bottom now inverted so camera aperture offsets in Y apply in the correct direction, we also need this flipped for eventual overscan support.
- ccam->motion_position logic updated to work based on relative shutter times, as camera->getShutter() returns absolute shutter values. With this, camera blur works as expected. Cycles seems fine with receiving either a positive or negative shuttertime so I simplified the logic a bit.

The behaviour of these changes has been visually compared with GafferArnold and the results look good to me.

M