### PR TITLE
 update for gaffer 0.59.4, python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dependencies/*/working
 .vscode
 NVIDIA-OptiX-SDK*
 /out
+build_local.sh
+NVIDIA-OptiX-SDK-7.1.0-linux64-x86_64.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,9 +263,11 @@ target_link_libraries(GafferCyclesModule
     ${GLOG_LIBRARIES}
     ${GFLAGS_LIBRARIES}
     )
+string(REPLACE "2" "python2.7" PYTHON_FOLDER ${PYTHON_VARIANT})
+string(REPLACE "3" "python3.7m" PYTHON_FOLDER ${PYTHON_FOLDER})
 target_include_directories(GafferCyclesModule PRIVATE 
     include ${GAFFER_ROOT}/include 
-    ${GAFFER_ROOT}/include/python2.7 
+    ${GAFFER_ROOT}/include/${PYTHON_FOLDER}
     ${CYCLES_INCLUDE_DIR}
     ${EMBREE_INCLUDE_DIRS}
     )

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ git clone --recurse-submodules https://github.com/boberfly/GafferCycles.git
 cd GafferCycles
 mkdir build
 cd build
-cmake -DCMAKE_CXX_COMPILER=g++-6 -DGAFFER_ROOT=$GAFFER_ROOT -DCMAKE_INSTALL_PREFIX=$GAFFERCYCLES ..
+cmake -DCMAKE_CXX_COMPILER=g++-6 -DGAFFER_ROOT=$GAFFER_ROOT -DPYTHON_VARIANT=3 -DCMAKE_INSTALL_PREFIX=$GAFFERCYCLES ..
 make install -j <num cores>
 ```
 
@@ -47,7 +47,7 @@ python ./build/build.py --project Embree --buildDir $GAFFERCYCLES --gafferRoot $
 python ./build/build.py --project OpenSubdiv --buildDir $GAFFERCYCLES --gafferRoot $GAFFER_ROOT --forceCCompiler gcc-6 --forceCxxCompiler g++-6
 python ./build/build.py --project OpenImageDenoise --buildDir $GAFFERCYCLES --gafferRoot $GAFFER_ROOT --forceCCompiler gcc-6 --forceCxxCompiler g++-6
 cd ../build
-cmake -DCMAKE_CXX_COMPILER=g++-6 -DGAFFER_ROOT=$GAFFER_ROOT -DCMAKE_INSTALL_PREFIX=$GAFFERCYCLES -DWITH_CYCLES_EMBREE=ON -DWITH_CYCLES_OPENSUBDIV=ON -DWITH_CYCLES_LOGGING=ON ..
+cmake -DCMAKE_CXX_COMPILER=g++-6 -DGAFFER_ROOT=$GAFFER_ROOT -DPYTHON_VARIANT=3 -DCMAKE_INSTALL_PREFIX=$GAFFERCYCLES -DWITH_CYCLES_EMBREE=ON -DWITH_CYCLES_OPENSUBDIV=ON -DWITH_CYCLES_LOGGING=ON ..
 make install -j <num cores>
 ```
 For OptiX, it will need to be installed from Nvidia's website and ```-DWITH_CYCLES_DEVICE_OPTIX=ON -DOPTIX_ROOT_DIR=$OPTIX_ROOT``` added to the cmake line.

--- a/build.py
+++ b/build.py
@@ -60,7 +60,7 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument(
 	"--gafferVersion",
-	default = "0.59.4.0",
+	default = "0.59.5.0",
 	help = "The version of Gaffer to build against. "
 )
 

--- a/build.py
+++ b/build.py
@@ -60,7 +60,7 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument(
 	"--gafferVersion",
-	default = "0.59.5.0",
+	default = "0.59.6.0",
 	help = "The version of Gaffer to build against. "
 )
 
@@ -298,7 +298,7 @@ gafferDirName = os.path.abspath( gafferDirName )
 
 # Download GafferCycles
 
-gafferCyclesURL = "https://github.com/boberfly/GafferCycles/archive/{version}.tar.gz".format( **formatVariables )
+gafferCyclesURL = "https://github.com/kubo-von/GafferCycles/archive/refs/tags/0.22.2.tar.gz" #"https://github.com/boberfly/GafferCycles/archive/{version}.tar.gz".format( **formatVariables )
 sys.stderr.write( "Downloading GafferCycles \"%s\"\n" % gafferCyclesURL )
 
 gafferCyclesDirName = "gaffercycles-{version}-source".format( **formatVariables )

--- a/build_docker_optix.sh
+++ b/build_docker_optix.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-python build.py --version 0.22.1 --cyclesVersion 0.22.0 --optix 1 --docker 1 --experimental 0 --upload 0 $@
+python build.py --version 0.22.2 --cyclesVersion 0.22.0 --optix 1 --docker 1 --experimental 0 --upload 0 $@

--- a/python/GafferCycles/__init__.py
+++ b/python/GafferCycles/__init__.py
@@ -36,7 +36,7 @@
 
 __import__( "GafferScene" )
 
-from _GafferCycles import *
-from CyclesShaderBall import CyclesShaderBall
+from . _GafferCycles import *
+from . CyclesShaderBall import CyclesShaderBall
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferCycles" )

--- a/python/GafferCyclesUI/__init__.py
+++ b/python/GafferCyclesUI/__init__.py
@@ -36,14 +36,14 @@
 
 __import__( "GafferSceneUI" )
 
-import CyclesAttributesUI
-import CyclesLightUI
-import CyclesMeshLightUI
-import CyclesOptionsUI
-import CyclesRenderUI
-import CyclesShaderBallUI
-import CyclesShaderUI
-import InteractiveCyclesRenderUI
-import ShaderMenu
+from . import CyclesAttributesUI
+from . import CyclesLightUI
+from . import CyclesMeshLightUI
+from . import CyclesOptionsUI
+from . import CyclesRenderUI
+from . import CyclesShaderBallUI
+from . import CyclesShaderUI
+from . import InteractiveCyclesRenderUI
+from . import ShaderMenu
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", {}, subdirectory = "GafferCyclesUI" )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -73,7 +73,7 @@ if moduleSearchPath.find( "GafferCycles" ) :
 		nodeMenu.append( "/Cycles/Interactive Render", GafferCycles.InteractiveCyclesRender, searchText = "InteractiveCyclesRender" )
 		nodeMenu.append( "/Cycles/Shader Ball", GafferCycles.CyclesShaderBall, searchText = "CyclesShaderBall" )
 
-	except Exception, m :
+	except Exception as m :
 
 		stacktrace = traceback.format_exc()
 		IECore.msg( IECore.Msg.Level.Error, "startup/gui/menus.py", "Error loading Cycles module - \"%s\".\n %s" % ( m, stacktrace ) )


### PR DESCRIPTION
Tested with build_docker_optix.sh to make working releases for gaffer 0.59,4 for both python 2 and 3 on linux
Might break docker.sh build for windows though, 